### PR TITLE
Added KeyFile support.

### DIFF
--- a/PDFXchangeEditor/PDFXchangeEditor.nuspec
+++ b/PDFXchangeEditor/PDFXchangeEditor.nuspec
@@ -29,9 +29,10 @@ The following package parameters can be set:
  * `/NoViewInBrowsers` - Do not configure to open PDF files inside browsers.
  * `/NoSetAsDefault` - Do not set as default application for PDF files.
  * `/NoProgramsMenuShortcuts` - Do not create program menu group for installed application and their components.
+ * `/KeyFile:[file]` - Pass [file] (which should be a .xcvault file downloaded from Tracker Software) in as your license file.
 
 These parameters can be passed to the installer with the use of `-params`.
-For example: `-params '"/NoDesktopShortcuts"'`.
+For example: `-params '"/NoDesktopShortcuts"'`, `--params "/KeyFile:C:\Users\foo\Temp\PDFXChangeEditor.xcvault"`.
 
 </description>
     <releaseNotes>https://www.tracker-software.com/product/pdf-xchange-editor/history</releaseNotes>

--- a/PDFXchangeEditor/tools/chocolateyInstall.ps1
+++ b/PDFXchangeEditor/tools/chocolateyInstall.ps1
@@ -104,6 +104,15 @@ if ($packageParameters) {
         $customArguments.Add("PROGRAMSMENU_SHORTCUTS", "0")
     }
 
+    if ($arguments.ContainsKey("KeyFile")) {
+        if ($arguments["KeyFile"] -eq "") {
+          Throw 'KeyFile needs a colon-separated argument; try something like this: --params "/KeyFile:C:\Users\foo\Temp\PDFXChangeEditor.xcvault".'
+        } else {
+          Write-Host "You want a KeyFile named $($arguments["KeyFile"])"
+          $customArguments.Add("KEYFILE", $arguments["KeyFile"])
+        }
+    }
+
 } else {
     Write-Debug "No Package Parameters Passed in"
 }


### PR DESCRIPTION
Here's the command lines I used for testing, after clearing all "Tracker Software" stuff out of the registry to kill the licenses (see ):

`choco install PDFXchangeEditor -dv -s .`

Checked, no license.  Removed with "choco uninstall".

`choco install PDFXchangeEditor -dv -s . --params "/KeyFile C:\Users\rlpowell\Dropbox\Windows_Automation_Secrets\PDFXChangeEditor.xcvault"
`

Errors out as intended:

```
ERROR: KeyFile needs a colon-separated argument; try something like this: --params "/KeyFile:C:\Users\foo\Temp\PDFXChangeEditor.xcvault".
 at <ScriptBlock>, C:\ProgramData\chocolatey\lib\PDFXchangeEditor\tools\chocolateyInstall.ps1: line 109
at <ScriptBlock>, C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1: line 48
at <ScriptBlock>, <No file>: line 1
```

Lastly:

` choco install PDFXchangeEditor -dv -s . --params "/KeyFile:C:\Users\rlpowell\Dropbox\Windows_Automation_Secrets\PDFXChangeEditor.xcvault"`

And license is in place as intended.