### PR TITLE
Fix vsts-cli 0.1.3 installer url

### DIFF
--- a/vsts-cli/tools/chocolateyinstall.ps1
+++ b/vsts-cli/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$url = 'https://vstscli.blob.core.windows.net/msi/vsts-cli-0.1.3.msi'
+$url = 'https://vstsclitool.blob.core.windows.net/msi/vsts-cli-0.1.3.msi'
 $checksum = 'dbb1f9fe24625352868ff740434802fd353f24d142c3d2083d61b1d25a95cd4d'
 
 $packageArgs = @{

--- a/vsts-cli/vsts-cli.nuspec
+++ b/vsts-cli/vsts-cli.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vsts-cli</id>
-    <version>0.1.3</version>
+    <version>0.1.3.20181129</version>
     <packageSourceUrl>https://github.com/flcdrg/au-packages/tree/master/vsts-cli</packageSourceUrl>
     <owners>flcdrg</owners>
     <title>VSTS CLI</title>


### PR DESCRIPTION
The installer url was changed to:
https://vstsclitool.blob.core.windows.net/msi/vsts-cli-0.1.3.msi
(see: https://docs.microsoft.com/en-us/cli/vsts/install?view=vsts-cli-latest).
