### PR TITLE
--addDeploymentGroupTags flag required for tags

### DIFF
--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -47,8 +47,8 @@ if ($pp['Url']) {
         }
 
         $configOpts += @("--deploymentGroup", "--deploymentGroupName", $pp['DeploymentGroupName'])
-        if ($pp['DeploymentGroupTags']) {
-            $configOpts += @("--deploymentGroupTags", $pp['DeploymentGroupTags'])
+        if ($pp['DeploymentGroupTags']) {            
+            $configOpts += @("--addDeploymentGroupTags", "--deploymentGroupTags", $pp['DeploymentGroupTags'])
         }
 
         if ($pp['ProjectName']) {

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -47,7 +47,7 @@ if ($pp['Url']) {
         }
 
         $configOpts += @("--deploymentGroup", "--deploymentGroupName", $pp['DeploymentGroupName'])
-        if ($pp['DeploymentGroupTags']) {            
+        if ($pp['DeploymentGroupTags']) {
             $configOpts += @("--addDeploymentGroupTags", "--deploymentGroupTags", $pp['DeploymentGroupTags'])
         }
 


### PR DESCRIPTION
Following the logic in the [listener's command settings](https://github.com/Microsoft/azure-pipelines-agent/blob/master/src/Agent.Listener/CommandSettings.cs), the `--addDeploymentGroupTags` flag is required to be set before it will parse the args for `--deploymentGroupTags`. 

Not adding this flag is preventing the package from properly registering a deployment agent with tags in AzureDevops