### PR TITLE
Add support for agent naming and agent replacement

### DIFF
--- a/azure-pipelines-agent/azure-pipelines-agent.nuspec
+++ b/azure-pipelines-agent/azure-pipelines-agent.nuspec
@@ -43,6 +43,8 @@ The following package parameters can be set:
  * `/LogonAccount:` - Account that agent should run as (either Windows Service or auto logon) - Specify the Windows user name in the format: domain\userName or userName@domain.com. To log in as Local System, use "NT AUTHORITY\SYSTEM". Defaults to NetworkService if not specified.
  * `/LogonPassword:` - Used with /LogonAccount. Windows logon password
  * `/Work:WorkDirectory` - Work directory where job data is stored. Defaults to _work under the root of the agent directory. The work directory is owned by a given agent and should not share between multiple agents.
+ * `/AgentName:Custom_Name` - Custom agent name (defaults to hostname)
+ * `/Replace` - Replace already registered agent with same name
 
 To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
 To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.    

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -81,6 +81,16 @@ if ($pp['Url']) {
     if ($pp['Work']) {
         $configOpts += @("--work", $pp['Work'])
     }
+
+    # Agent name
+    if ($pp['AgentName']) {
+        $configOpts += @("--agent", $pp['AgentName'])
+    }
+
+    # Replace existing agent
+    if ($pp['Replace']) {
+        $configOpts += @("--replace")
+    }
 }
 
 $packageArgs = @{


### PR DESCRIPTION
Useful for auto-deployment to be able to programattically name agents
Replacement allows for idempotent redeployment of agents.