### PR TITLE
[redgate packages] Update scripts to use new urls at https://download.red-gate.com/installers

### DIFF
--- a/SqlSearch/tools/chocolateyInstall.ps1
+++ b/SqlSearch/tools/chocolateyInstall.ps1
@@ -1,36 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $checksum = 'AD91C5A582861006FA5AAE5B378E328C4A5A9125CB9B24C2AA4DA88A7ADC34CC'
-$primaryDownloadUrl = 'https://download.red-gate.com/SQL_Search.exe'
-$secondaryDownloadUrl = 'ftp://support.red-gate.com/patches/SQLSearch/03Sep2019/SQLSearch.exe'
-$packageVersionLastModified = New-Object -TypeName DateTimeOffset 2019, 9, 3, 12, 47, 27, 0 # Last modified time corresponding to this package version
-
-$pp = Get-PackageParameters
-
-if ($pp["FTP"] -ne $null -and $pp["FTP"] -ne '') { 
-
-  # FTP forced  
-    $url = $secondaryDownloadUrl
-} else {
-
-  # Red Gate have a fixed download URL, but if the binary changes we can fall back to their FTP site
-  # so the package doesn't break
-  $headers = Get-WebHeaders -url $primaryDownloadUrl
-  $lastModifiedHeader = $headers.'Last-Modified'
-
-  $lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
-
-  Write-Verbose "Package LastModified: $packageVersionLastModified"
-  Write-Verbose "HTTP Last Modified  : $lastModified"
-
-  if ($lastModified -ne $packageVersionLastModified) {
-    Write-Warning "The download available at $primaryDownloadUrl has changed from what this package was expecting. Falling back to FTP for version-specific URL"
-    $url = $secondaryDownloadUrl
-  } else {
-    Write-Verbose "Primary URL matches package expectation"
-    $url = $primaryDownloadUrl
-  }
-}
+$url = 'ftp://support.red-gate.com/patches/SQLSearch/03Sep2019/SQLSearch.exe'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/SqlSearch/update.ps1
+++ b/SqlSearch/update.ps1
@@ -1,1 +1,1 @@
-..\redgate\common.ps1 "SQL_Search" "SQLSearch"
+..\redgate\common.ps1 "SQL_Search" "SQLSearch" -readVersionFromInstaller

--- a/SqlSearch/update.ps1
+++ b/SqlSearch/update.ps1
@@ -1,1 +1,1 @@
-..\redgate\common.ps1 "SQL_Search" "SQLSearch" -readVersionFromInstaller
+..\redgate\common.ps1 "SQL_Search" -readVersionFromInstaller

--- a/dotnetdeveloperbundle/dotnetdeveloperbundle.nuspec
+++ b/dotnetdeveloperbundle/dotnetdeveloperbundle.nuspec
@@ -23,19 +23,6 @@
 - ANTS Performance Profiler Pro - Get a complete picture of your application's performance and find bottlenecks, whether in the code or database.
 - ANTS Memory Profiler - Find memory leaks within minutes and optimize the memory usage of your C# and VB.NET code.
 - .NET Reflector VSPro - Understand and debug any 3rd party code, including frameworks, components and libraries.
-
-#### Package Download Fallback
-This package will fallback to the Red Gate FTP site once the main fixed URL no longer matches the version for which this package was created. This is to ensure that a specific version of the Chocolatey package continues to work even after Red Gate releases newer versions.
-
-When a newer version of the package is published, it will then revert to using the primary https download URL.
-
-#### Package Parameters
-The following package parameters can be set:
-
- * `/FTP` - Force using the FTP download URL
-
-These parameters can be passed to the installer with the use of `--params`.
-For example: `--params "'/FTP'"`.
 </description>
     <releaseNotes>- [ANTS Memory Profiler](https://documentation.red-gate.com/display/AMP8/ANTS+Memory+Profiler+8.11+release+notes)
 - [ANTS Performance Profiler](https://documentation.red-gate.com/display/APP9/ANTS+Performance+Profiler+9.6+release+notes)

--- a/dotnetdeveloperbundle/tools/chocolateyinstall.ps1
+++ b/dotnetdeveloperbundle/tools/chocolateyinstall.ps1
@@ -1,36 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $checksum = '3122E9E12DB6FBDA152E528DFD72876B4A098DCD217975EA185CF2842C335032'
-$primaryDownloadUrl = 'https://download.red-gate.com/DotNETDeveloperBundle.exe'
-$secondaryDownloadUrl = 'ftp://support.red-gate.com/patches/DotNETDeveloperBundle/24Sep2019/DotNETDeveloperBundle.exe'
-$packageVersionLastModified = New-Object -TypeName DateTimeOffset 2019, 9, 24, 13, 13, 41, 0 # Last modified time corresponding to this package version
-
-$pp = Get-PackageParameters
-
-if ($pp["FTP"] -ne $null -and $pp["FTP"] -ne '') { 
-
-  # FTP forced  
-    $url = $secondaryDownloadUrl
-} else {
-
-  # Red Gate have a fixed download URL, but if the binary changes we can fall back to their FTP site
-  # so the package doesn't break
-  $headers = Get-WebHeaders -url $primaryDownloadUrl
-  $lastModifiedHeader = $headers.'Last-Modified'
-
-  $lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
-
-  Write-Verbose "Package LastModified: $packageVersionLastModified"
-  Write-Verbose "HTTP Last Modified  : $lastModified"
-
-  if ($lastModified -ne $packageVersionLastModified) {
-    Write-Warning "The download available at $primaryDownloadUrl has changed from what this package was expecting. Falling back to FTP for version-specific URL"
-    $url = $secondaryDownloadUrl
-  } else {
-    Write-Verbose "Primary URL matches package expectation"
-    $url = $primaryDownloadUrl
-  }
-}
+$url = 'ftp://support.red-gate.com/patches/DotNETDeveloperBundle/24Sep2019/DotNETDeveloperBundle.exe'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/redgate/common.ps1
+++ b/redgate/common.ps1
@@ -1,12 +1,7 @@
 param(
     [string] $name,
-    [string] $alternateName,
     [switch] $readVersionFromInstaller
 )
-
-if (-not ($alternateName)) {
-    $alternateName = $name
-}
 
 import-module au
 
@@ -32,7 +27,7 @@ function global:au_GetLatest {
         # and the main https://download.red-gate.com/<name>.exe is just a redirect.
         # so use the url with the date to keep the chocolatey package stable and do away with checksum errors.
         $dateReleased = $lastModified.ToString("yyyy-MM-dd")
-        $downloadUrl = "https://download.red-gate.com/installers/$alternateName/$dateReleased/$alternateName.exe"
+        $downloadUrl = "https://download.red-gate.com/installers/$name/$dateReleased/$name.exe"
 
         $downloadedFile = [IO.Path]::GetTempFileName()
 

--- a/redgate/common.ps1
+++ b/redgate/common.ps1
@@ -49,7 +49,7 @@ function global:au_GetLatest {
                 # Some of Redgate's installers are bundles of other installers. (The toolbelts and dev bundles)
                 # In that case, the version number embedded in the installer is irrelevant.
                 # So use the date the installer was released instead.
-                $version = $dateReleased
+                $version = $lastModified.ToString("yyyy.MM.dd")
             }
             Write-Verbose "$version"
             $checksum = (Get-FileHash $downloadedFile -Algorithm SHA256).Hash

--- a/redgate/common.ps1
+++ b/redgate/common.ps1
@@ -1,6 +1,7 @@
 param(
     [string] $name,
-    [string] $alternateName
+    [string] $alternateName,
+    [switch] $readVersionFromInstaller
 )
 
 if (-not ($alternateName)) {
@@ -10,13 +11,10 @@ if (-not ($alternateName)) {
 import-module au
 
 function global:au_SearchReplace {
-    $d = [DateTimeOffset] $Latest.LastModified
     @{
         'tools\chocolateyInstall.ps1' = @{
-            "(^[$]secondaryDownloadUrl\s*=\s*)(['`"].*['`"])"      = "`$1'$($Latest.URL32)'"
+            "(^[$]url\s*=\s*)(['`"].*['`"])"      = "`$1'$($Latest.URL32)'"
             "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-            # $packageVersionLastModified = New-Object -TypeName DateTimeOffset 2017, 7, 3, 11, 5, 0, 0 # Last modified time corresponding to this package version
-            "(^[$]packageVersionLastModified\s*=\s*)(.*)(\s+\#)" = "`$1New-Object -TypeName DateTimeOffset $($d.Year), $($d.Month), $($d.Day), $($d.Hour), $($d.Minute), $($d.Second), 0`$3"
         }
     }
 }
@@ -30,20 +28,29 @@ function global:au_GetLatest {
         $lastModifiedHeader = $response.Headers.'Last-Modified'
         $lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
 
-        # Infer what the FTP download should be and grab that to find out the version (and indirectly confirm that the URL is correct)
-        # $secondaryDownloadUrl = "ftp://support.red-gate.com/patches/SQLToolbelt/03Jul2017/SQLToolbelt.exe"
-        $secondaryDownloadUrl = "ftp://support.red-gate.com/patches/$alternateName/$($lastModified.ToString("ddMMMyyyy"))/$alternateName.exe"
+        # Redgate's installers are uploaded to https://download.red-gate.com/installers/<name>/<date-released>/<name>.exe
+        # and the main https://download.red-gate.com/<name>.exe is just a redirect.
+        # so use the url with the date to keep the chocolatey package stable and do away with checksum errors.
+        $dateReleased = $lastModified.ToString("yyyy-MM-dd")
+        $downloadUrl = "https://download.red-gate.com/installers/$alternateName/$dateReleased/$alternateName.exe"
 
         $downloadedFile = [IO.Path]::GetTempFileName()
 
-        Write-Verbose "Downloading $secondaryDownloadUrl"
+        Write-Verbose "Downloading $downloadUrl"
         try {
             
             $client = new-object System.Net.WebClient
-            $client.DownloadFile($secondaryDownloadUrl, $downloadedFile)
+            $client.DownloadFile($downloadUrl, $downloadedFile)
 
-            # SqlSearch has strange FileVersion, so use FileVersionRaw as that seems correct
-            $version = (get-item $downloadedFile).VersionInfo.FileVersionRaw
+            if($readVersionFromInstaller.IsPresent) {
+                # SqlSearch has strange FileVersion, so use FileVersionRaw as that seems correct
+                $version = (get-item $downloadedFile).VersionInfo.FileVersionRaw
+            } else {
+                # Some of Redgate's installers are bundles of other installers. (The toolbelts and dev bundles)
+                # In that case, the version number embedded in the installer is irrelevant.
+                # So use the date the installer was released instead.
+                $version = $dateReleased
+            }
             Write-Verbose "$version"
             $checksum = (Get-FileHash $downloadedFile -Algorithm SHA256).Hash
             Write-Verbose "$checksum"
@@ -51,14 +58,14 @@ function global:au_GetLatest {
             Remove-Item $downloadedFile
 
             $Latest = @{ 
-                URL32 = $secondaryDownloadUrl
+                URL32 = $downloadUrl
                 Version = $version
                 Checksum32 = $checksum
                 LastModified = $lastModified
             }
         }
         catch {
-            Write-Warning "Could not find file $secondaryDownloadUrl"
+            Write-Warning "Could not find file $downloadUrl"
             $Latest = 'ignore'
         }
     } catch {

--- a/sqltoolbelt/sqltoolbelt.nuspec
+++ b/sqltoolbelt/sqltoolbelt.nuspec
@@ -41,20 +41,13 @@ Tools in the SQL Toolbelt:
 - SQL Change Automation Powershell - Automates database development solutions
 - SQL Change Automation - Develop and deploy databases in Visual Studio with migration scripts
 
-#### Package Download Fallback
-This package will fallback to the Red Gate FTP site once the main fixed URL no longer matches the version for which this package was created. This is to ensure that a specific version of the Chocolatey package continues to work even after Red Gate releases newer versions.
-
-When a newer version of the package is published, it will then revert to using the primary https download URL.
-
 #### Package Parameters
 The following package parameters can be set:
 
- * `/FTP` - Force using the FTP download URL
- * `/NoFTP` - Don't fallback to FTP if HTTPS modified time is different (using this risks a checksum mismatch if file is actually a newer version)
  * `/products` - Only install the specified products (see tools\chocolateyinstall.ps1 for supported named)
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params "/FTP /products:'SQL Compare, SQL Data Compare'"`.
+For example: `--params "/products:'SQL Compare, SQL Data Compare'"`.
 </description>
   <releaseNotes>https://www.red-gate.com/products/roadmap</releaseNotes>
   <dependencies>

--- a/sqltoolbelt/tools/chocolateyinstall.ps1
+++ b/sqltoolbelt/tools/chocolateyinstall.ps1
@@ -1,9 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$primaryDownloadUrl = "https://download.red-gate.com/SQLToolbelt.exe"
-$secondaryDownloadUrl = 'ftp://support.red-gate.com/patches/SQLToolbelt/10Sep2019/SQLToolbelt.exe'
-$packageVersionLastModified = New-Object -TypeName DateTimeOffset 2019, 9, 10, 13, 40, 46, 0 # Last modified time corresponding to this package version
+$url = 'ftp://support.red-gate.com/patches/SQLToolbelt/10Sep2019/SQLToolbelt.exe'
 $checksum = '9BEB3A2F65382792E3F7F766D20381E76F5A6840072E8CDA233E06DD05D68AEE'
 
 $validProductPackageNames = @(
@@ -44,37 +42,6 @@ if ($pp["products"] -ne $null -and $pp["products"] -ne ''){
 }
 
 $commandArgs += "/IAgreeToTheEula"
-
-$url = $primaryDownloadUrl
-
-if ($pp["FTP"] -ne $null -and $pp["FTP"] -ne '') { 
-
-  # FTP forced
-  Write-Verbose "Using $secondaryDownloadUrl because /FTP was specified"
-  $url = $secondaryDownloadUrl
-} else {
-
-  # Red Gate has a fixed download URL, but if the binary changes we can fall back to their FTP site
-  # so the package doesn't break
-  $headers = Get-WebHeaders -url $primaryDownloadUrl
-  $lastModifiedHeader = $headers.'Last-Modified'
-
-  $lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
-
-  Write-Verbose "Package LastModified: $packageVersionLastModified"
-  Write-Verbose "HTTP Last Modified  : $lastModified"
-
-  if ($lastModified -ne $packageVersionLastModified) {
-    if ($pp["NoFTP"]) {
-      Write-Warning "The download available at $primaryDownloadUrl has changed from what this package was expecting, but /NoFTP package parameter was supplied. Expect checksums to fail if the download is actually a newer version."
-    } else {
-      Write-Warning "The download available at $primaryDownloadUrl has changed from what this package was expecting. Falling back to FTP for version-specific URL"
-      $url = $secondaryDownloadUrl
-    }
-  } else {
-    Write-Verbose "Primary URL matches package expectation"
-  }
-}
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
Hi @flcdrg,

I'm working at Redgate and have been upgrading the way we host our installers at https://download.red-gate.com

I can see that the way we used to do things must have caused quiet a bit of pain to keep chocolatey packages up to date. Sorry about that!

I'm hoping this PR can keep the chocolatey packages up to date and easier to maintain in the future.

From now on:
* https://download.red-gate.com can be browsed to see where things are.
* The main downloads https://download.red-gate.com/SQLToolbelt.exe, https://download.red-gate.com/SQL_Search.exe, https://download.red-gate.com/DotNETDeveloperBundle.exe all redirect to a url that is versioned. The redirects will be updated as we release new versions.
  * For example: https://download.red-gate.com/SQLToolbelt.exe currently redirect to https://download.red-gate.com/installers/SQLToolbelt/2019-09-27/SQLToolbelt.exe (which shouldn't change anymore)

So we can now have the chocolatey packages download files using `https://download.red-gate.com/installers/<name>/<date>/<name>.exe` and this should always work.

We are also considering taking our support FTP offline so I have removed any mention of it. With these changes, the FTP fallback shouldn't be needed anymore.

One more thing: the version numbers embedded in `DotNetDeveloperBundle.exe` and `SQLToolbelt.exe` are completely irrelevant. Mostly because these are just bundles of some of our tools. So rather than having the packages use the number from the file, I suggest we use the date at which they were released. (e.g. Let's consider that today's SQLToobelt.exe is version `2019.27.09`)

I hope this all makes sense and can help keep the chocolatey packages working 😃