### PR TITLE
Workaround to avoid checksum mismatches with the Redgate SQLToolbelt

### DIFF
--- a/redgate/common.ps1
+++ b/redgate/common.ps1
@@ -23,6 +23,15 @@ function global:au_GetLatest {
         $lastModifiedHeader = $response.Headers.'Last-Modified'
         $lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
 
+        if([datetimeoffset](get-date) -lt $lastModified.AddDays(-1)){
+            # Make sure the release is at least 1 day old before we make a package for it.
+            # That's because Redgate can sometimes release toolbelts multiple times per day.
+            # Because installers are released in a yyyy-MM-dd subfolder, previous installers
+            # released in the same day are overriden which will cause
+            # checksums to mismatch if we generate the chocolatey package too quickly.
+            return 'ignore'
+        }
+
         # Redgate's installers are uploaded to https://download.red-gate.com/installers/<name>/<date-released>/<name>.exe
         # and the main https://download.red-gate.com/<name>.exe is just a redirect.
         # so use the url with the date to keep the chocolatey package stable and do away with checksum errors.


### PR DESCRIPTION
Wait 1 day after a toolbelt release before generating the chocolatey package.

So that we won't risk getting checksum mismatchs if a toolbelt installer is released more than once in a given day. 

(If a toolbelt is released twice in the same day, the installer at at `https://download.red-gate.com/installers/SQLToolbelt/<yyyy-MM-dd>/SQLToolbelt.exe` gets overwritten)

