### PR TITLE
Proposed fix for IGNOREPENDINGREBOOT for SQL Server 2019 installer

### DIFF
--- a/sql-server-2019/tools/chocolateyinstall.ps1
+++ b/sql-server-2019/tools/chocolateyinstall.ps1
@@ -12,19 +12,25 @@ $pp = Get-PackageParameters
 
 if ( (!$pp['IGNOREPENDINGREBOOT']) -and (Get-PendingReboot).RebootPending) {
   Write-Error "A system reboot is pending. You must restart Windows first before installing SQL Server"
-} else if ($pp['IGNOREPENDINGREBOOT']) {
-  $pp.Remove('IGNOREPENDINGREBOOT')
-  if(!$pp['ACTION']) $pp['ACTION']='Install'
-  if(!$pp['SkipRules']) $pp['SkipRules']='RebootRequiredCheck'
+} else {
+  if ($pp['IGNOREPENDINGREBOOT']) {
+    $pp.Remove('IGNOREPENDINGREBOOT')
+    if(!$pp['ACTION']) {
+      $pp['ACTION']='Install'
+    }
+    if(!$pp['SkipRules']) {
+      $pp['SkipRules']='RebootRequiredCheck'
+    }
+  }
 }
 
 # Default to use supplied configuration file and current user as sysadmin
-if (!$pp['CONFIGURATIONFILE']) { 
+if (!$pp['CONFIGURATIONFILE']) {
   $pp['CONFIGURATIONFILE'] = "$toolsDir\ConfigurationFile.ini"
 }
 
-if (!$pp['SQLSYSADMINACCOUNTS']) { 
-  $pp['SQLSYSADMINACCOUNTS'] = "$env:USERDOMAIN\$env:USERNAME" 
+if (!$pp['SQLSYSADMINACCOUNTS']) {
+  $pp['SQLSYSADMINACCOUNTS'] = "$env:USERDOMAIN\$env:USERNAME"
 }
 
 $packageArgs = @{
@@ -47,11 +53,11 @@ if (!$pp['IsoPath']) {
   $chocTempDir = $env:TEMP
   $tempDir = Join-Path $chocTempDir "$($env:chocolateyPackageName)"
   if ($env:chocolateyPackageVersion -ne $null) {
-     $tempDir = Join-Path $tempDir "$($env:chocolateyPackageVersion)"; 
+     $tempDir = Join-Path $tempDir "$($env:chocolateyPackageVersion)";
   }
 
   $tempDir = $tempDir -replace '\\chocolatey\\chocolatey\\', '\chocolatey\'
-  if (![System.IO.Directory]::Exists($tempDir)) { 
+  if (![System.IO.Directory]::Exists($tempDir)) {
     [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null
   }
 
@@ -69,9 +75,9 @@ try {
   $MountResult = Mount-DiskImage -ImagePath $fileFullPath -StorageType ISO -PassThru
   $MountVolume = $MountResult | Get-Volume
   $MountLocation = "$($MountVolume.DriveLetter):"
-  
-  Install-ChocolateyInstallPackage @packageArgs -File "$($MountLocation)\setup.exe"  
+
+  Install-ChocolateyInstallPackage @packageArgs -File "$($MountLocation)\setup.exe"
 }
 finally {
-  Dismount-DiskImage -ImagePath $fileFullPath  
+  Dismount-DiskImage -ImagePath $fileFullPath
 }

--- a/sql-server-2019/tools/chocolateyinstall.ps1
+++ b/sql-server-2019/tools/chocolateyinstall.ps1
@@ -12,7 +12,7 @@ $pp = Get-PackageParameters
 
 if ( (!$pp['IGNOREPENDINGREBOOT']) -and (Get-PendingReboot).RebootPending) {
   Write-Error "A system reboot is pending. You must restart Windows first before installing SQL Server"
-} else {
+} else if ($pp['IGNOREPENDINGREBOOT']) {
   $pp.Remove('IGNOREPENDINGREBOOT')
   if(!$pp['ACTION']) $pp['ACTION']='Install'
   if(!$pp['SkipRules']) $pp['SkipRules']='RebootRequiredCheck'

--- a/sql-server-2019/tools/chocolateyinstall.ps1
+++ b/sql-server-2019/tools/chocolateyinstall.ps1
@@ -12,6 +12,10 @@ $pp = Get-PackageParameters
 
 if ( (!$pp['IGNOREPENDINGREBOOT']) -and (Get-PendingReboot).RebootPending) {
   Write-Error "A system reboot is pending. You must restart Windows first before installing SQL Server"
+} else {
+  $pp.Remove('IGNOREPENDINGREBOOT')
+  if(!$pp['ACTION']) $pp['ACTION']='Install'
+  if(!$pp['SkipRules']) $pp['SkipRules']='RebootRequiredCheck'
 }
 
 # Default to use supplied configuration file and current user as sysadmin


### PR DESCRIPTION
If you use the `IGNOREPENDINGREBOOT` flag, it is currently passed through to the SQL Server installer, which causes it to fail with error -2068578301.

Per https://support.microsoft.com/en-au/help/2008982/you-are-repeatedly-prompted-to-restart-the-computer-when-installing-sq and https://speverything.wordpress.com/2014/02/04/sql-install-bypass-the-restart-computer-setup-support-rule/comment-page-1/, the following alternative flags should passed into setup: `/ACTION=Install /SkipRules=RebootRequiredCheck`.