### PR TITLE
Add support for --environment and --environmentName parameters

### DIFF
--- a/azure-pipelines-agent/azure-pipelines-agent.nuspec
+++ b/azure-pipelines-agent/azure-pipelines-agent.nuspec
@@ -41,6 +41,7 @@ The following package parameters can be set:
  * `/DeploymentGroupName:` - Used with /DeploymentGroup. Deployment group for the agent to join
  * `/DeploymentGroupTags:` - Used with /DeploymentGroup. A comma separated list of tags for the deployment group agent. For example "web, db".
  * `/EnvironmentName` - Used with /Environment. Name of the environment to add the VM/machine as a resource to.
+    NOTE: Environment resources can be tagged in Azure DevOps, but the command line argument (`--virtualmachineresourcetags`) for adding tags during registration does not seem to work (as of June 8, 2020)
  * `/AutoLogon` - Configure auto logon and run the agent on startup (The default if this is not specified, is to run the agent as a Windows Service)
  * `/LogonAccount:` - Account that agent should run as (either Windows Service or auto logon) - Specify the Windows user name in the format: domain\userName or userName@domain.com. To log in as Local System, use "NT AUTHORITY\SYSTEM". Defaults to NetworkService if not specified.
  * `/LogonPassword:` - Used with /LogonAccount. Windows logon password

--- a/azure-pipelines-agent/azure-pipelines-agent.nuspec
+++ b/azure-pipelines-agent/azure-pipelines-agent.nuspec
@@ -41,7 +41,7 @@ The following package parameters can be set:
  * `/DeploymentGroupName:` - Used with /DeploymentGroup. Deployment group for the agent to join
  * `/DeploymentGroupTags:` - Used with /DeploymentGroup. A comma separated list of tags for the deployment group agent. For example "web, db".
  * `/EnvironmentName` - Used with /Environment. Name of the environment to add the VM/machine as a resource to.
- * `/EnvironmentTags:` - Used with /Environment. A comma separated list of tags for the deployment group agent. For example "web, db".
+ * `/EnvironmentTags:` - Used with /Environment. A comma separated list of tags for the environment resource. For example "web, db".
  * `/AutoLogon` - Configure auto logon and run the agent on startup (The default if this is not specified, is to run the agent as a Windows Service)
  * `/LogonAccount:` - Account that agent should run as (either Windows Service or auto logon) - Specify the Windows user name in the format: domain\userName or userName@domain.com. To log in as Local System, use "NT AUTHORITY\SYSTEM". Defaults to NetworkService if not specified.
  * `/LogonPassword:` - Used with /LogonAccount. Windows logon password

--- a/azure-pipelines-agent/azure-pipelines-agent.nuspec
+++ b/azure-pipelines-agent/azure-pipelines-agent.nuspec
@@ -36,9 +36,11 @@ The following package parameters can be set:
  * `/Password:` - Used with `negotiate` or `alt`
  * `/Pool:` - Pool name for the agent to join (defaults to `default`)
  * `/DeploymentGroup` - Install as deployment agent (instead of a build agent)
- * `/ProjectName:` - Used with /DeploymentGroup. Team project name
+ * `/Environment` - Install as an environment virtual machine (instead of a build agent)
+ * `/ProjectName:` - Used with /DeploymentGroup or /Environment. Team project name
  * `/DeploymentGroupName:` - Used with /DeploymentGroup. Deployment group for the agent to join
  * `/DeploymentGroupTags:` - Used with /DeploymentGroup. A comma separated list of tags for the deployment group agent. For example "web, db".
+ * `/EnvironmentName` - Used with /Environment. Name of the environment to add the VM/machine as a resource to.
  * `/AutoLogon` - Configure auto logon and run the agent on startup (The default if this is not specified, is to run the agent as a Windows Service)
  * `/LogonAccount:` - Account that agent should run as (either Windows Service or auto logon) - Specify the Windows user name in the format: domain\userName or userName@domain.com. To log in as Local System, use "NT AUTHORITY\SYSTEM". Defaults to NetworkService if not specified.
  * `/LogonPassword:` - Used with /LogonAccount. Windows logon password

--- a/azure-pipelines-agent/azure-pipelines-agent.nuspec
+++ b/azure-pipelines-agent/azure-pipelines-agent.nuspec
@@ -41,7 +41,7 @@ The following package parameters can be set:
  * `/DeploymentGroupName:` - Used with /DeploymentGroup. Deployment group for the agent to join
  * `/DeploymentGroupTags:` - Used with /DeploymentGroup. A comma separated list of tags for the deployment group agent. For example "web, db".
  * `/EnvironmentName` - Used with /Environment. Name of the environment to add the VM/machine as a resource to.
-    NOTE: Environment resources can be tagged in Azure DevOps, but the command line argument (`--virtualmachineresourcetags`) for adding tags during registration does not seem to work (as of June 8, 2020)
+ * `/EnvironmentTags:` - Used with /Environment. A comma separated list of tags for the deployment group agent. For example "web, db".
  * `/AutoLogon` - Configure auto logon and run the agent on startup (The default if this is not specified, is to run the agent as a Windows Service)
  * `/LogonAccount:` - Account that agent should run as (either Windows Service or auto logon) - Specify the Windows user name in the format: domain\userName or userName@domain.com. To log in as Local System, use "NT AUTHORITY\SYSTEM". Defaults to NetworkService if not specified.
  * `/LogonPassword:` - Used with /LogonAccount. Windows logon password

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -70,6 +70,7 @@ if ($pp['Url']) {
 
         # TODO: Environment Resources in Azure Pipelines have a notion of tagging resources (i.e. VM's)
         # Haven't found how/if it's possible to set that during agent registration (documentation on this feature is non-existent)
+        # Update - Looked through MSFT's agent source and found that the command line argument is called `--virtualmachineresourcetags`, but it doesn't seem to do anything
     }
     else {
         if (!$pp['Pool']) { $pp['Pool'] = 'default'}

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -64,13 +64,13 @@ if ($pp['Url']) {
 
         $configOpts += @("--environment", "--environmentName", $pp['EnvironmentName'])
 
+        if ($pp['EnvironmentTags']) {
+            $configOpts += @("--addVirtualMachineResourceTags", "--virtualMachineResourceTags", $pp['EnvironmentTags'])
+        }
+
         if ($pp['ProjectName']) {
             $configOpts += @('--projectName', $pp['ProjectName'])
         }
-
-        # TODO: Environment Resources in Azure Pipelines have a notion of tagging resources (i.e. VM's)
-        # Haven't found how/if it's possible to set that during agent registration (documentation on this feature is non-existent)
-        # Update - Looked through MSFT's agent source and found that the command line argument is called `--virtualmachineresourcetags`, but it doesn't seem to do anything
     }
     else {
         if (!$pp['Pool']) { $pp['Pool'] = 'default'}

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -38,7 +38,7 @@ if ($pp['Url']) {
             $configOpts += @("--userName", $username, "--password", $password)
         }
     }
-    # Are we a deployment agent or a build agent?
+    # Are we a deployment agent, environment, or a build agent?
     if ($pp['DeploymentGroup']) {
         Write-Verbose "Deployment Agent"
 
@@ -50,6 +50,19 @@ if ($pp['Url']) {
         if ($pp['DeploymentGroupTags']) {
             $configOpts += @("--addDeploymentGroupTags", "--deploymentGroupTags", $pp['DeploymentGroupTags'])
         }
+
+        if ($pp['ProjectName']) {
+            $configOpts += @('--projectName', $pp['ProjectName'])
+        }
+    }
+    elseif ($pp['Environment']) {
+        Write-Verbose "Environment Agent"
+
+        if (!$pp['EnvironmentName'] -or !$pp['ProjectName']) {
+            Write-Error "Must specify /EnvironmentName and /ProjectName"
+        }
+
+        $configOpts += @("--environment", "--environmentName", $pp['EnvironmentName'])
 
         if ($pp['ProjectName']) {
             $configOpts += @('--projectName', $pp['ProjectName'])

--- a/azure-pipelines-agent/tools/chocolateyinstall.ps1
+++ b/azure-pipelines-agent/tools/chocolateyinstall.ps1
@@ -67,6 +67,9 @@ if ($pp['Url']) {
         if ($pp['ProjectName']) {
             $configOpts += @('--projectName', $pp['ProjectName'])
         }
+
+        # TODO: Environment Resources in Azure Pipelines have a notion of tagging resources (i.e. VM's)
+        # Haven't found how/if it's possible to set that during agent registration (documentation on this feature is non-existent)
     }
     else {
         if (!$pp['Pool']) { $pp['Pool'] = 'default'}


### PR DESCRIPTION
Azure Pipelines has added a feature called Environments, which can be used to deploy applications to Kubernetes clusters, or groups of generic virtual machines.

Registering a virtual machine with an Environment uses the same VSTS/Azure Pipelines Agent that we are all used to, but it uses different command line arguments, that, aside from the PowerShell script that Microsoft provides on the "Add Resource" page, appear to be undocumented.

These code changes do work with the choco package, however, and I was able to register a machine with Azure Pipelines and have it added into an Environment.

~~The only thing I wasn't able to do was add support for 'tagging' virtual machines that are onboarded. The Azure Agent source code accepts a command line argument (`--virtualmachineresourcetags`), but it didn't seem to do anything in my testing.~~

~~At the very least, this will allow you to install the agent on a VM and register it with Azure Pipelines as an Environment Resource.~~
*EDIT: Of course I find the solution after submitting a PR. Support for environment tags added! Thanks to the author of [this issue](https://github.com/microsoft/azure-pipelines-agent/issues/2973) for the solution.*

Give me a shout with any questions or concerns.

Thanks!

(Fixes #83)