### PR TITLE
Enables SQLSYSADMINACCOUNTS option in configuration.ini

### DIFF
--- a/sql-server-2019/README.md
+++ b/sql-server-2019/README.md
@@ -53,7 +53,7 @@ All other package parameters are passed through to SQL Server Setup, allowing yo
 The following are set by default:
 
 - `/ConfigurationFile:` - The path to a configurationfile.ini - defaults to the supplied tools\configurationfile.ini
-- `/SQLSYSADMINACCOUNTS:` - The usernames to add to the SQL SysAdmin role - defaults to current user
+- `/SQLSYSADMINACCOUNTS:` - A username or group to add to the SQL SysAdmin role - defaults to current user. This option is only set if configurationfile.ini does not contain 'SQLSYSADMINACCOUNTS=' at the start of a line. 
 
 See https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt#Install for the full list of parameters supported by SQL Server.
 

--- a/sql-server-2019/sql-server-2019.nuspec
+++ b/sql-server-2019/sql-server-2019.nuspec
@@ -71,7 +71,7 @@ All other package parameters are passed through to SQL Server Setup, allowing yo
 The following are set by default:
 
 - `/ConfigurationFile:` - The path to a configurationfile.ini - defaults to the supplied tools\configurationfile.ini
-- `/SQLSYSADMINACCOUNTS:` - The usernames to add to the SQL SysAdmin role - defaults to current user
+- `/SQLSYSADMINACCOUNTS:` - A username or group to add to the SQL SysAdmin role - defaults to current user. This option is only set if configurationfile.ini does not contain 'SQLSYSADMINACCOUNTS=' at the start of a line. 
 
 See https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt#Install for the full list of parameters supported by SQL Server.
 

--- a/sql-server-2019/tools/chocolateyinstall.ps1
+++ b/sql-server-2019/tools/chocolateyinstall.ps1
@@ -30,7 +30,10 @@ if (!$pp['CONFIGURATIONFILE']) {
 }
 
 if (!$pp['SQLSYSADMINACCOUNTS']) {
-  $pp['SQLSYSADMINACCOUNTS'] = "$env:USERDOMAIN\$env:USERNAME"
+  # Test for prensence of "^SQLSYSADMINACCOUNTS=" in the ini. Add the default if not
+  if ((Get-Content -Path $($pp['CONFIGURATIONFILE'])) -notmatch "^SQLSYSADMINACCOUNTS=") {
+    $pp['SQLSYSADMINACCOUNTS'] = "$env:USERDOMAIN\$env:USERNAME"
+  }
 }
 
 $packageArgs = @{

--- a/sql-server-2019/tools/chocolateyinstall.ps1
+++ b/sql-server-2019/tools/chocolateyinstall.ps1
@@ -30,8 +30,8 @@ if (!$pp['CONFIGURATIONFILE']) {
 }
 
 if (!$pp['SQLSYSADMINACCOUNTS']) {
-  # Test for prensence of "^SQLSYSADMINACCOUNTS=" in the ini. Add the default if not
-  if ((Get-Content -Path $($pp['CONFIGURATIONFILE'])) -notmatch "^SQLSYSADMINACCOUNTS=") {
+  # Test for presence of "^SQLSYSADMINACCOUNTS=" in the ini - add the default only if not present
+  if (-not ((Get-Content -Path $($pp['CONFIGURATIONFILE'])) -match "^SQLSYSADMINACCOUNTS=")) {
     $pp['SQLSYSADMINACCOUNTS'] = "$env:USERDOMAIN\$env:USERNAME"
   }
 }


### PR DESCRIPTION
#109
If you explicitly use the command line option `/SQLSYSADMINACCOUNTS`, the installer will ignore `SQLSYSADMINACCOUNTS=` in the configuration.ini. There is no change to this in this PR - this is how the installer works (command line options take presedence to configuration.ini)

Earlier, if you did not explicitly use the command line option `/SQLSYSADMINACCOUNTS`, chocolateyinstall.ps1 would add the command line option with the current (executing) user. So the command line option would always exist, and - since it take presedence over the ini - always override the `SQLSYSADMINACCOUNTS=` in configuration.ini. 

The PR simply adds a test for the presence of the string `SQLSYSADMINACCOUNTS=` at the start of any line (i.e. `"^SQLSYSADMINACCOUNTS="`) in the configuration.ini, and only adds the command line option `/SQLSYSADMINACCOUNTS` with the default value if such a line could not be found. 

Also changed the lines describing the command line option `/SQLSYSADMINACCOUNTS:` because the current implementation supports a single identity, not multiple. The installer expects something like `/SQLSYSADMINACCOUNTS:DOMAN\User1 DOMAIN\Group2`, but is always met with `/SQLSYSADMINACCOUNTS:"DOMAN\User1 DOMAIN\Group2"` - treating them as a single identity. However, as long as the ini-file option works, this is minor.

Tested with 'Test-Package'. 