### PR TITLE
(fix) Update 32bit installer URL for Mirth

### DIFF
--- a/mirth.install/update.ps1
+++ b/mirth.install/update.ps1
@@ -33,7 +33,7 @@ function global:au_GetLatest {
     }
 
     # Download links are in body, which is markdown
-    if ($response.body -match '\((https://[\w\/\.\-]+windows\.exe)\)') {
+    if ($response.body -match '\((https://[\w\/\.\-]+windows-x32\.exe)\)') {
         $latest.URL32 = $Matches[1]
     } else {
         # if no windows link, then not a release we care about


### PR DESCRIPTION
It looks like NextGen Healthcare started appending the 32bit installer with `-x32` some time ago which has caused the workflow not to pick up on available updates. This should fix that.