### PR TITLE
OBS NDI: Update auto update url to point to renamed project

### DIFF
--- a/obs-ndi/update.ps1
+++ b/obs-ndi/update.ps1
@@ -7,7 +7,7 @@ param (
 
 $ErrorActionPreference = 'Stop'
 
-$obsNdiUrl = 'https://api.github.com/repos/obs-ndi/obs-ndi/releases/latest'
+$obsNdiUrl = 'https://api.github.com/repos/DistroAV/DistroAV/releases/latest'
 
 function global:au_BeforeUpdate {
   $Latest.Checksum32 = Get-RemoteChecksum -Url $Latest.Url32 -Algorithm 'SHA256'


### PR DESCRIPTION
I've only updated the url to point to the renamed project for OBS NDI. But since the AU module has been archived the Chocolatey community has created a new module to replace AU called chocolatey-au. This new module is practically a 1:1 replacement of the AU module. So if you would like to update to it, I could include that in this PR as well. Just let me know.