### PR TITLE
[consul] Revert use of chocolateyInstallArguments

### DIFF
--- a/consul/tools/chocolateyInstall.ps1
+++ b/consul/tools/chocolateyInstall.ps1
@@ -27,10 +27,7 @@ if (-not ($packageParameters["noservice"])) {
   $serviceLogDirectory = "$serviceInstallationDirectory\logs"
   $serviceConfigDirectory = "$serviceInstallationDirectory\config"
   $serviceDataDirectory = "$serviceInstallationDirectory\data"
-  $installArguments = $env:chocolateyInstallArguments
-  if (-not ($installArguments)) {
-    $installArguments = ""
-  }
+  $packageParameters = $env:chocolateyPackageParameters
 
   # Create Service Directories
   Write-Host "Creating $serviceLogDirectory"
@@ -76,7 +73,7 @@ if (-not ($packageParameters["noservice"])) {
 
   Write-Host "Installing service: $serviceName"
   # Install the service
-  & $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory $installArguments" | Out-Null
+  & $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory $packageParameters" | Out-Null
   & $wrapperExe set $serviceName AppEnvironmentExtra GOMAXPROCS=$env:NUMBER_OF_PROCESSORS | Out-Null
   & $wrapperExe set $serviceName ObjectName NetworkService | Out-Null
   & $wrapperExe set $serviceName AppStdout "$serviceLogDirectory\consul-output.log" | Out-Null


### PR DESCRIPTION
The use of chocolateyInstallArguments was causing the package to fail automated validation checks due to not complying with https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0016/