### PR TITLE
fix(option): user-agent make installer crash

### DIFF
--- a/dellcommandupdate/tools/chocolateyinstall.ps1
+++ b/dellcommandupdate/tools/chocolateyinstall.ps1
@@ -16,7 +16,6 @@ $packageArgs = @{
   checksum      = $checksum
   checksumType  = $checksumType
   destination   = $toolsDir
-  options       = @{ Headers = @{ 'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0' } }
 }
 
 Install-ChocolateyPackage @packageArgs 


### PR DESCRIPTION
When installing original version


Downloading dellcommandupdate
  from 'https://downloads.dell.com/FOLDER11914075M/1/Dell-Command-Update-Application_6VFWW_WIN_5.4.0_A00.EXE'.
ERROR: The 'User-Agent' header must be modified using the appropriate property or method.
Parameter name: name
The install of dellcommandupdate was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\DellCommandUpdate\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

After removing the user agent, it all went OK :)