### PR TITLE
PDFExchange :: Typo error in the nuspec file (editor only) and 2 url upadated

### DIFF
--- a/PDFXchangeEditor/PDFXchangeEditor.nuspec
+++ b/PDFXchangeEditor/PDFXchangeEditor.nuspec
@@ -11,10 +11,10 @@
     <projectUrl>https://www.pdf-xchange.com/product/pdf-xchange-editor</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/flcdrg/au-packages@master/PDFXchangeEditor/icons/pdfxchangeeditor.png</iconUrl>
     <copyright>2001-2025 PDF-XChange Co Ltd. Registered in England: N0.11091579</copyright>
-    <licenseUrl>https://www.pdf-xchange.com/licensing<</licenseUrl>
+    <licenseUrl>https://www.pdf-xchange.com/licensing</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://help.pdf-xchange.com/pdfxe10/</docsUrl>
-    <mailingListUrl>https://forum.pdf-xchange.com/viewforum.php?f=62<</mailingListUrl>
+    <mailingListUrl>https://forum.pdf-xchange.com/viewforum.php?f=62</mailingListUrl>
     <!--<bugTrackerUrl></bugTrackerUrl>-->
     <tags>PDFXchangeEditor pdf reader editor ocr pdfxchangeviewer admin</tags>
     <summary>The smallest, fastest, most feature-rich PDF editor/viewer available! Create, View, Edit, Annotate, OCR and Digitally Sign PDF files plus much more..</summary>

--- a/PDFXchangeEditor/update.ps1
+++ b/PDFXchangeEditor/update.ps1
@@ -21,7 +21,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
 
     try {
-        $response = Invoke-RestMethod -Uri "https://www.tracker-software.com/trackerupdate/TrackerData8.xml"
+        $response = Invoke-RestMethod -Uri "https://downloads.pdf-xchange.com/trackerupdate/TrackerData8.xml"
 
         # Trim off any Byte Order Mark
         $xml = [xml] $response.Trim([char] 0xFEFF, [char] 0x200B)
@@ -49,7 +49,7 @@ function global:au_GetLatest {
         $lastModifiedHeader = $response.Headers.'Last-Modified'
         $x86lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
 
-        $response = Invoke-WebRequest  $primaryDownloadUrl64 -Method Head -UseBasicParsing
+        $response = Invoke-WebRequest $primaryDownloadUrl64 -Method Head -UseBasicParsing
         $lastModifiedHeader = $response.Headers.'Last-Modified'
         $x64lastModified = [DateTimeOffset]::Parse($lastModifiedHeader, [Globalization.CultureInfo]::InvariantCulture)
 

--- a/PDFXchangePro/update.ps1
+++ b/PDFXchangePro/update.ps1
@@ -21,7 +21,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
 
     try {
-        $response = Invoke-RestMethod -Uri "https://www.tracker-software.com/trackerupdate/TrackerData8.xml"
+        $response = Invoke-RestMethod -Uri "https://downloads.pdf-xchange.com/trackerupdate/TrackerData8.xml"
 
         # Trim off any Byte Order Mark
         $xml = [xml] $response.Trim([char] 0xFEFF, [char] 0x200B)


### PR DESCRIPTION
2 extra change:
1. Made a typo error in the nuspec file for the Editor
2. Forgot to update URL in the update script to the new domain.