### PR TITLE
[microsoft-teams-new-bootstraper] Add IsWVDEnvironment registry key on VDI

### DIFF
--- a/microsoft-teams-new-bootstrapper/tools/chocolateyinstall.ps1
+++ b/microsoft-teams-new-bootstrapper/tools/chocolateyinstall.ps1
@@ -28,6 +28,13 @@ Get-ChocolateyWebFile @packageArgs
 & $downloadPath -p
 
 if($pp['VDI']){
+
+  $regHive = "HKLM:\SOFTWARE\Microsoft\Teams"
+  if (-not (Test-Path $regHive)) {
+    New-Item -Path $regHive 
+  }
+  New-ItemProperty -Path $regHive -Name IsWVDEnvironment -Value 1 -PropertyType DWord
+
   $teamsVersion = Get-AppXPackage -Name "*msteams*" | Select-Object -ExpandProperty Version
   # Check if $teamsVersion is empty and attempt an alternative method if so
   if (-not $teamsVersion) {


### PR DESCRIPTION
This Registry key is needed according to the Microsoft Deplyoment guide for new Teams for VDI, to make media redirection / optimization work:
https://learn.microsoft.com/en-us/microsoftteams/new-teams-vdi-requirements-deploy

We have that installed on all our VDIs environments to make it work, despite MS stating it only works for Azure/M365.
