### PR TITLE
fix: Use CDN for icon to follow chocolatey requirements

### DIFF
--- a/consul/consul.nuspec
+++ b/consul/consul.nuspec
@@ -48,7 +48,7 @@ IMPROVEMENTS:
 
 ]]></releaseNotes>
     <summary>Consul is a tool for service discovery, monitoring and configuration.</summary>
-    <iconUrl>https://cdn.rawgit.com/calvn/chocolatey-consul/master/icons/consul.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/flcdrg/au-packages/master/consul/icons/consul.png</iconUrl>
     
     <copyright>HashiCorp 2019</copyright>
     <tags>consul service consul.io</tags>


### PR DESCRIPTION
This package is no longer updating due to failed validation "CPMR0076: Icon URL uses a URL that is a RawGit URL." (https://ch0.co/rules/cpmr0076).

This commit updates the icon url to not only use the CDN, but to base it off the icon in the new GitHub repository and not the archived repository.

The package hasn't been updated for 11 months likely due to this error.